### PR TITLE
Make theme module configurable 

### DIFF
--- a/docs/release-notes/rl-0.1.adoc
+++ b/docs/release-notes/rl-0.1.adoc
@@ -30,3 +30,7 @@ vim.luaConfigRC = lib.nvim.dag.entryAnywhere "config here"
 https://github.com/MoritzBoehme[MoritzBoehme]:
 
 * `catppuccin` theme is now available as a neovim theme <<opt-vim.theme.style>> and lualine theme <<opt-vim.statusline.lualine.theme>>.
+
+https://github.com/antotocar34[antotocar34]:
+
+* Refactored supported theme definitions into a module. This allows any downstream users to define their own themes.

--- a/modules/theme/default.nix
+++ b/modules/theme/default.nix
@@ -7,5 +7,6 @@
   imports = [
     ./theme.nix
     ./config.nix
+    ./supported_themes.nix
   ];
 }

--- a/modules/theme/supported_themes.nix
+++ b/modules/theme/supported_themes.nix
@@ -1,33 +1,79 @@
 {
-  onedark = {
-    setup = { style ? "dark" }: ''
-      -- OneDark theme
-      require('onedark').setup {
-        style = "${style}"
-      }
-      require('onedark').load()
-    '';
-    styles = [ "dark" "darker" "cool" "deep" "warm" "warmer" ];
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  l = lib // builtins;
+  t = l.types;
+  themeSubmodule.options = {
+    setup = l.mkOption {
+      type = t.str;
+      description = "Lua code to initialize theme";
+    };
+    styles = l.mkOption {
+      type = t.nullOr (t.listOf t.str);
+      default = null;
+    };
+  };
+in
+{
+  options.vim.theme = {
+    supportedThemes = l.mkOption {
+      type = t.attrsOf (t.submodule themeSubmodule);
+      description = "Supported themes";
+    };
   };
 
-  tokyonight = {
-    setup = { style ? "night" }: ''
-      -- need to set style before colorscheme to apply
-      vim.g.tokyonight_style = '${style}'
-      vim.cmd[[colorscheme tokyonight]]
-    '';
-    styles = [ "day" "night" "storm" ];
-  };
+  config.vim.theme.supportedThemes = 
+  let
+    cfg = config.vim.theme;
+    style = cfg.style;
+  in
+  {
+    onedark = 
+    let
+      defaultStyle = "dark";
+    in
+    {
+      setup = ''
+        -- OneDark theme
+        require('onedark').setup {
+        style = "${if (l.isNull style) then defaultStyle else style}"
+        }
+        require('onedark').load()
+      '';
+      styles = [ "dark" "darker" "cool" "deep" "warm" "warmer" ];
+    };
 
-  catppuccin = {
-    setup = { style ? "mocha" }: ''
-      -- Catppuccin theme
-      require('catppuccin').setup {
-        flavour = "${style}"
-      }
-      -- setup must be called before loading
-      vim.cmd.colorscheme "catppuccin"
-    '';
-    styles = [ "latte" "frappe" "macchiato" "mocha" ];
+    tokyonight = 
+    let
+      defaultStyle = "night";
+    in
+    {
+      setup = ''
+        -- need to set style before colorscheme to apply
+        vim.g.tokyonight_style = '${if (l.isNull style) then defaultStyle else style}'
+        vim.cmd[[colorscheme tokyonight]]
+      '';
+      styles = [ "day" "night" "storm" ];
+    };
+
+    catppuccin = 
+    let
+      defaultStyle = "mocha";
+    in
+      {
+      setup = ''
+        -- Catppuccin theme
+        require('catppuccin').setup {
+        flavour = "${if (l.isNull style) then defaultStyle else style}"
+        }
+        -- setup must be called before loading
+        vim.cmd.colorscheme "catppuccin"
+      '';
+      styles = [ "latte" "frappe" "macchiato" "mocha" ];
+    };
   };
 }

--- a/modules/theme/theme.nix
+++ b/modules/theme/theme.nix
@@ -8,7 +8,6 @@ with lib;
 with lib.attrsets;
 with builtins; let
   cfg = config.vim.theme;
-  supported_themes = import ./supported_themes.nix;
 in {
   options.vim.theme = {
     enable = mkOption {
@@ -17,13 +16,14 @@ in {
     };
 
     name = mkOption {
-      type = types.enum (attrNames supported_themes);
-      description = "Supported themes can be found in `supported_themes.nix`";
+      type = types.enum (attrNames cfg.supportedThemes);
+      description = "Supported themes can be found in `supportedThemes.nix`";
     };
 
     style = mkOption {
-      type = with types; enum supported_themes.${cfg.name}.styles;
+      type = with types; nullOr (enum cfg.supportedThemes.${cfg.name}.styles);
       description = "Specific style for theme if it supports it";
+      default = null; 
     };
 
     extraConfig = mkOption {
@@ -35,6 +35,6 @@ in {
   config = mkIf cfg.enable {
     vim.startPlugins = [cfg.name];
     vim.luaConfigRC.themeSetup = nvim.dag.entryBefore ["theme"] cfg.extraConfig;
-    vim.luaConfigRC.theme = supported_themes.${cfg.name}.setup {style = cfg.style;};
+    vim.luaConfigRC.theme = cfg.supportedThemes.${cfg.name}.setup;
   };
 }


### PR DESCRIPTION
Allows user to add their own themes when using `neovim-flake` as an input.
Example (which we may want to add to docs once `extra-inputs` is merged into `master`).
```nix
{
  inputs = {
      neovim-flake.url = "path:antotocar34/neovim-flake?ref=theme_modularize";

      nord = {
        url = "github:shaunsingh/nord.nvim";
        flake = false;
      };
  };

  outputs = {nixpkgs, neovim-flake, ...}@inputs: let
    system = "x86_64-linux";
    pkgs = nixpkgs.legacyPackages.${system};

    configModule.config.vim = {
      theme.enable = true;
      theme.name = "nord";
      theme.supportedThemes."nord" = {
        setup = ''
        require('nord').set()
        vim.cmd[[colorscheme nord]]
        '';
      };
    };

    customNeovim = neovim-flake.lib.neovimConfiguration {
      extraInputs = {
        inherit (inputs) nord;
      };
      modules = [ configModule ];
      inherit pkgs;
    };
  in {
    packages.${system}.neovim = customNeovim.neovim;
  };
}
```