### PR TITLE
Check client capability before formatting

### DIFF
--- a/modules/lsp/lsp.nix
+++ b/modules/lsp/lsp.nix
@@ -204,8 +204,10 @@ in {
             buffer = bufnr,
             callback = function()
               if vim.g.formatsave then
+                if client.supports_method("textDocument/formatting") then
                   local params = require'vim.lsp.util'.make_formatting_params({})
                   client.request('textDocument/formatting', params, nil, bufnr)
+                end
               end
             end
           })


### PR DESCRIPTION
Hi, thanks for putting together this project! Not sure if you're interested in contributions, so feel free to close without comment if not, but:

When editing Python files, I am receiving a pyright error claiming that the `textDocument/formatting` method is unhandled. I guess pyright just doesn't support formatting, which is ok here, because null-ls is doing the formatting just fine. This change simply prevents pyright from even receiving said request and thus suppresses the (harmless) error message.