### PR TITLE
Extend configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -255,12 +255,29 @@
       lib ? pkgs.lib,
       check ? true,
       extraSpecialArgs ? {},
-    }:
-      modulesWithInputs {
+    }: let
+      output = modulesWithInputs {
         inherit pkgs lib check extraSpecialArgs;
         configuration = {...}: {
           imports = modules;
         };
+      };
+    in
+      output
+      // {
+        neovim =
+          output.neovim
+          // {
+            extendConfiguration = args:
+              (neovimConfiguration {
+                modules = modules ++ (args.modules or []);
+                pkgs = args.pkgs or pkgs;
+                lib = args.lib or lib;
+                check = args.check or check;
+                extraSpecialArgs = extraSpecialArgs // (args.extraSpecialArgs or {});
+              })
+              .neovim;
+          };
       };
 
     nvimBin = pkg: "${pkg}/bin/nvim";

--- a/flake.nix
+++ b/flake.nix
@@ -294,82 +294,82 @@
       };
     };
 
-    mainConfig = isMaximal: {
-      config = {
-        vim.viAlias = false;
-        vim.vimAlias = true;
-        vim.lsp = {
-          enable = true;
-          formatOnSave = true;
-          lightbulb.enable = true;
-          lspsaga.enable = false;
-          nvimCodeActionMenu.enable = true;
-          trouble.enable = true;
-          lspSignature.enable = true;
-          nix = {
-            enable = true;
-            formatter = "alejandra";
-          };
-          rust.enable = isMaximal;
-          python = isMaximal;
-          clang.enable = isMaximal;
-          sql = isMaximal;
-          ts = isMaximal;
-          go = isMaximal;
-          zig.enable = isMaximal;
+    mainConfig = isMaximal: {lib, ...}: let
+      overridable = lib.mkOverride 1200; # between mkOptionDefault and mkDefault
+    in {
+      vim.viAlias = overridable false;
+      vim.vimAlias = overridable true;
+      vim.lsp = {
+        enable = overridable true;
+        formatOnSave = overridable true;
+        lightbulb.enable = overridable true;
+        lspsaga.enable = overridable false;
+        nvimCodeActionMenu.enable = overridable true;
+        trouble.enable = overridable true;
+        lspSignature.enable = overridable true;
+        nix = {
+          enable = overridable true;
+          formatter = overridable "alejandra";
         };
-        vim.visuals = {
-          enable = true;
-          nvimWebDevicons.enable = true;
-          lspkind.enable = true;
-          indentBlankline = {
-            enable = true;
-            fillChar = "";
-            eolChar = "";
-            showCurrContext = true;
-          };
-          cursorWordline = {
-            enable = true;
-            lineTimeout = 0;
-          };
-        };
-        vim.statusline.lualine = {
-          enable = true;
-          theme = "onedark";
-        };
-        vim.theme = {
-          enable = true;
-          name = "onedark";
-          style = "darker";
-        };
-        vim.autopairs.enable = true;
-        vim.autocomplete = {
-          enable = true;
-          type = "nvim-cmp";
-        };
-        vim.filetree.nvimTreeLua.enable = true;
-        vim.tabline.nvimBufferline.enable = true;
-        vim.treesitter = {
-          enable = true;
-          context.enable = true;
-        };
-        vim.keys = {
-          enable = true;
-          whichKey.enable = true;
-        };
-        vim.telescope = {
-          enable = true;
-        };
-        vim.markdown = {
-          enable = true;
-          glow.enable = true;
-        };
-        vim.git = {
-          enable = true;
-          gitsigns.enable = true;
-        };
-        vim.plantuml.enable = true;
+        rust.enable = overridable isMaximal;
+        python = overridable isMaximal;
+        clang.enable = overridable isMaximal;
+        sql = overridable isMaximal;
+        ts = overridable isMaximal;
+        go = overridable isMaximal;
+        zig.enable = overridable isMaximal;
       };
+      vim.visuals = {
+        enable = overridable true;
+        nvimWebDevicons.enable = overridable true;
+        lspkind.enable = overridable true;
+        indentBlankline = {
+          enable = overridable true;
+          fillChar = overridable "";
+          eolChar = overridable "";
+          showCurrContext = overridable true;
+        };
+        cursorWordline = {
+          enable = overridable true;
+          lineTimeout = overridable 0;
+        };
+      };
+      vim.statusline.lualine = {
+        enable = overridable true;
+        theme = overridable "onedark";
+      };
+      vim.theme = {
+        enable = overridable true;
+        name = overridable "onedark";
+        style = overridable "darker";
+      };
+      vim.autopairs.enable = overridable true;
+      vim.autocomplete = {
+        enable = overridable true;
+        type = overridable "nvim-cmp";
+      };
+      vim.filetree.nvimTreeLua.enable = overridable true;
+      vim.tabline.nvimBufferline.enable = overridable true;
+      vim.treesitter = {
+        enable = overridable true;
+        context.enable = overridable true;
+      };
+      vim.keys = {
+        enable = overridable true;
+        whichKey.enable = overridable true;
+      };
+      vim.telescope = {
+        enable = overridable true;
+      };
+      vim.markdown = {
+        enable = overridable true;
+        glow.enable = overridable true;
+      };
+      vim.git = {
+        enable = overridable true;
+        gitsigns.enable = overridable true;
+      };
+      vim.plantuml.enable = overridable true;
     };
 
     nixConfig = mainConfig false;

--- a/modules/git/config.nix
+++ b/modules/git/config.nix
@@ -7,8 +7,8 @@
 with lib; {
   config = {
     vim.git = {
-      enable = mkDefault false;
-      gitsigns.enable = mkDefault false;
+      enable = mkOptionDefault false;
+      gitsigns.enable = mkOptionDefault false;
     };
   };
 }

--- a/modules/markdown/config.nix
+++ b/modules/markdown/config.nix
@@ -7,8 +7,8 @@
 with lib; {
   config = {
     vim.markdown = {
-      enable = mkDefault false;
-      glow.enable = mkDefault false;
+      enable = mkOptionDefault false;
+      glow.enable = mkOptionDefault false;
     };
   };
 }

--- a/modules/statusline/config.nix
+++ b/modules/statusline/config.nix
@@ -7,22 +7,22 @@
 with lib; {
   config = {
     vim.statusline.lualine = {
-      enable = mkDefault false;
+      enable = mkOptionDefault false;
 
-      icons = mkDefault true;
-      theme = mkDefault "auto";
+      icons = mkOptionDefault true;
+      theme = mkOptionDefault "auto";
       sectionSeparator = {
-        left = mkDefault "";
-        right = mkDefault "";
+        left = mkOptionDefault "";
+        right = mkOptionDefault "";
       };
 
       componentSeparator = {
-        left = mkDefault "⏽";
-        right = mkDefault "⏽";
+        left = mkOptionDefault "⏽";
+        right = mkOptionDefault "⏽";
       };
 
       activeSection = {
-        a = mkDefault "{'mode'}";
+        a = mkOptionDefault "{'mode'}";
         b = ''
           {
             {
@@ -32,8 +32,8 @@ with lib; {
             "diff",
           }
         '';
-        c = mkDefault "{'filename'}";
-        x = mkDefault ''
+        c = mkOptionDefault "{'filename'}";
+        x = mkOptionDefault ''
           {
             {
               "diagnostics",
@@ -48,17 +48,17 @@ with lib; {
             "encoding",
           }
         '';
-        y = mkDefault "{'progress'}";
-        z = mkDefault "{'location'}";
+        y = mkOptionDefault "{'progress'}";
+        z = mkOptionDefault "{'location'}";
       };
 
       inactiveSection = {
-        a = mkDefault "{}";
-        b = mkDefault "{}";
-        c = mkDefault "{'filename'}";
-        x = mkDefault "{'location'}";
-        y = mkDefault "{}";
-        z = mkDefault "{}";
+        a = mkOptionDefault "{}";
+        b = mkOptionDefault "{}";
+        c = mkOptionDefault "{'filename'}";
+        x = mkOptionDefault "{'location'}";
+        y = mkOptionDefault "{}";
+        z = mkOptionDefault "{}";
       };
     };
   };

--- a/modules/theme/config.nix
+++ b/modules/theme/config.nix
@@ -1,11 +1,16 @@
-{ pkgs, config, lib, ... }:
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
 with lib; {
   config = {
     vim.theme = {
-      enable = mkDefault false;
-      name = mkDefault "onedark";
-      style = mkDefault "darker";
-      extraConfig = mkDefault "";
+      enable = mkOptionDefault false;
+      name = mkOptionDefault "onedark";
+      style = mkOptionDefault "darker";
+      extraConfig = mkOptionDefault "";
     };
   };
 }

--- a/modules/visuals/config.nix
+++ b/modules/visuals/config.nix
@@ -1,27 +1,28 @@
-{ pkgs
-, config
-, lib
-, ...
+{
+  pkgs,
+  config,
+  lib,
+  ...
 }:
 with lib; {
   config = {
     vim.visuals = {
-      enable = mkDefault false;
+      enable = mkOptionDefault false;
 
-      nvimWebDevicons.enable = mkDefault false;
-      lspkind.enable = mkDefault false;
+      nvimWebDevicons.enable = mkOptionDefault false;
+      lspkind.enable = mkOptionDefault false;
 
       cursorWordline = {
-        enable = mkDefault false;
-        lineTimeout = mkDefault 500;
+        enable = mkOptionDefault false;
+        lineTimeout = mkOptionDefault 500;
       };
 
       indentBlankline = {
-        enable = mkDefault false;
-        listChar = mkDefault "│";
-        fillChar = mkDefault "⋅";
-        eolChar = mkDefault "↴";
-        showCurrContext = mkDefault true;
+        enable = mkOptionDefault false;
+        listChar = mkOptionDefault "│";
+        fillChar = mkOptionDefault "⋅";
+        eolChar = mkOptionDefault "↴";
+        showCurrContext = mkOptionDefault true;
       };
     };
   };


### PR DESCRIPTION
Fixes #23 

Gives `neovim` packages a `extendConfiguration` property, which is a method allowing users to extend this package's configurations with additional modules.

This allows users e.g. to derive `.#nix` config to generate their own config, assign that to global `neovim` package, and then in per-project's `shell.nix`, expand the config to include additional LSP modules or plugins, instead of having to redefine everything from `neovimConfiguration`.