### PR TITLE
Build packages inside module

### DIFF
--- a/docs/custom-configs.adoc
+++ b/docs/custom-configs.adoc
@@ -1,15 +1,13 @@
 [[ch-custom-configuration]]
 == Custom Configuration
 
-Custom configuration is done with the `neovimConfiguration` function. It takes in the configuration as a module. The output of the configuration function is an attrset.
+Custom configuration is done with the `neovimConfiguration` function. It takes in the configuration as a list of modules. The output of the configuration function is the configured neovim package. Additionally, information about the module is given in the package's `meta` attributes.
 
 [source,nix]
 ----
 {
-  options = "The options that were available to configure";
-  config = "The outputted configuration";
-  pkgs = "The package set used to evaluate the module";
-  neovim = "The built neovim package";
+  meta.module.options = "The final module options";
+  meta.module.config = "The final module configuration";
 }
 ----
 
@@ -35,7 +33,7 @@ The following is an example of a barebones vim configuration with the default th
       inherit pkgs;
     };
   in {
-    packages.${system}.neovim = customNeovim.neovim;
+    packages.${system}.neovim = customNeovim;
   };
 }
 ----

--- a/docs/release-notes/rl-0.1.adoc
+++ b/docs/release-notes/rl-0.1.adoc
@@ -27,6 +27,14 @@ If you are contributing and adding a new plugin, add the plugin name to `availab
 vim.luaConfigRC = lib.nvim.dag.entryAnywhere "config here"
 ----
 
+* Builds are done within the module evaluation. You can override the neovim package used by setting <<opt-build.package>>. There is no more `.neovim` attribute from the configuration function, the output is the package itself. See the manual for accessing the `meta` attributes.
+
+* You can now add your own custom inputs as plugins. See <<opt-build.rawPlugins>>. They can be accessed in <<opt-vim.startPlugins>> & <<opt-vim.optPlugins>>
+
+* Settings aliases has been moved to the `config.build` namespace: <<opt-build.viAlias>> & <<opt-build.vimAlias>>
+
+* Internally, now using the modern https://github.com/NixOS/nixpkgs/blob/c47370e2cc335cb987577ff5fa26c9f29cc7774e/pkgs/applications/editors/neovim/utils.nix#L24[makeNeovimConfig] and https://github.com/NixOS/nixpkgs/blob/c47370e2cc335cb987577ff5fa26c9f29cc7774e/pkgs/applications/editors/neovim/wrapper.nix#L11[wrapNeovimUnstable] for building the final package, <<opt-built.package>>
+
 https://github.com/MoritzBoehme[MoritzBoehme]:
 
 * `catppuccin` theme is now available as a neovim theme <<opt-vim.theme.style>> and lualine theme <<opt-vim.statusline.lualine.theme>>.

--- a/modules/build/default.nix
+++ b/modules/build/default.nix
@@ -1,0 +1,149 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+with builtins; let
+  cfgBuild = config.build;
+  cfgBuilt = config.built;
+  cfgVim = config.vim;
+
+  inputsSubmodule = {...}: {
+    options.src = mkOption {
+      description = "The plugin source";
+      type = types.package;
+    };
+  };
+in {
+  options = {
+    build = {
+      viAlias = mkOption {
+        description = "Enable vi alias";
+        type = types.bool;
+        default = true;
+      };
+
+      vimAlias = mkOption {
+        description = "Enable vim alias";
+        type = types.bool;
+        default = true;
+      };
+
+      rawPlugins = mkOption {
+        description = "Plugins that are just the source, usually from a flake input";
+        type = with types; attrsOf (submodule inputsSubmodule);
+        default = {};
+      };
+
+      package = mkOption {
+        description = "Neovim to use for neovim-flake";
+        type = types.package;
+        default = pkgs.neovim-unwrapped;
+      };
+    };
+
+    built = {
+      configRC = mkOption {
+        description = "The final built config";
+        type = types.lines;
+        readOnly = true;
+      };
+
+      startPlugins = mkOption {
+        description = "The final built start plugins";
+        type = with types; listOf package;
+        readOnly = true;
+      };
+
+      optPlugins = mkOption {
+        description = "The final built opt plugins";
+        type = with types; listOf package;
+        readOnly = true;
+      };
+
+      package = mkOption {
+        description = "The final wrapped and configured neovim package";
+        type = types.package;
+        readOnly = true;
+      };
+    };
+  };
+
+  config = let
+    buildPlug = name:
+      pkgs.vimUtils.buildVimPluginFrom2Nix rec {
+        pname = name;
+        version = "master";
+        src = assert asserts.assertMsg (name != "nvim-treesitter") "Use buildTreesitterPlug for building nvim-treesitter.";
+          cfgBuild.rawPlugins.${pname}.src;
+      };
+
+    treeSitterPlug = pkgs.vimPlugins.nvim-treesitter.withPlugins (_: config.vim.treesitter.grammars);
+
+    buildConfigPlugins = plugins:
+      map
+      (plug: (
+        if isString plug
+        then
+          (
+            if (plug == "nvim-treesitter")
+            then treeSitterPlug
+            else buildPlug plug
+          )
+        else plug
+      ))
+      (filter
+        (f: f != null)
+        plugins);
+
+    normalizedPlugins =
+      cfgBuilt.startPlugins
+      ++ (map (plugin: {
+          inherit plugin;
+          optional = true;
+        })
+        cfgBuilt.optPlugins);
+
+    neovimConfig = pkgs.neovimUtils.makeNeovimConfig {
+      inherit (cfgBuild) viAlias vimAlias;
+      plugins = normalizedPlugins;
+      customRC = cfgBuilt.configRC;
+    };
+  in {
+    built = {
+      configRC = let
+        mkSection = r: ''
+          " SECTION: ${r.name}
+          ${r.data}
+        '';
+        mapResult = r: (concatStringsSep "\n" (map mkSection r));
+        vimConfig = nvim.dag.resolveDag {
+          name = "vim config script";
+          dag = cfgVim.configRC;
+          inherit mapResult;
+        };
+      in
+        vimConfig;
+
+      startPlugins = buildConfigPlugins cfgVim.startPlugins;
+      optPlugins = buildConfigPlugins cfgVim.optPlugins;
+
+      package =
+        (pkgs.wrapNeovimUnstable cfgBuild.package (neovimConfig
+          // {
+            wrapRc = true;
+          }))
+        .overrideAttrs (oldAttrs: {
+          meta =
+            oldAttrs.meta
+            // {
+              module = {
+                inherit config options;
+              };
+            };
+        });
+    };
+  };
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,14 +1,10 @@
-{inputs}: {
-  configuration,
+{
+  modules ? [],
   pkgs,
   lib ? pkgs.lib,
   check ? true,
   extraSpecialArgs ? {},
 }: let
-  inherit (pkgs) neovim-unwrapped wrapNeovim vimPlugins;
-  inherit (builtins) map filter isString toString getAttr hasAttr attrNames;
-  inherit (pkgs.vimUtils) buildVimPluginFrom2Nix;
-
   extendedLib = import ./lib/stdlib-extended.nix lib;
 
   nvimModules = import ./modules.nix {
@@ -17,56 +13,12 @@
   };
 
   module = extendedLib.evalModules {
-    modules = [configuration] ++ nvimModules;
+    modules = modules ++ nvimModules;
     specialArgs =
       {
-        modulesPath = toString ./.;
+        modulesPath = builtins.toString ./.;
       }
       // extraSpecialArgs;
   };
-
-  buildPlug = name:
-    buildVimPluginFrom2Nix rec {
-      pname = name;
-      version = "master";
-      src = assert lib.asserts.assertMsg (name != "nvim-treesitter") "Use buildTreesitterPlug for building nvim-treesitter.";
-        getAttr pname inputs;
-    };
-
-  buildTreesitterPlug = grammars: vimPlugins.nvim-treesitter.withPlugins (_: grammars);
-
-  vimOptions = module.config.vim;
-
-  buildConfigPlugins = plugins:
-    map
-    (plug: (
-      if (isString plug)
-      then
-        (
-          if (plug == "nvim-treesitter")
-          then (buildTreesitterPlug vimOptions.treesitter.grammars)
-          else (buildPlug plug)
-        )
-      else plug
-    ))
-    (filter
-      (f: f != null)
-      plugins);
-
-  neovim = wrapNeovim neovim-unwrapped {
-    viAlias = vimOptions.viAlias;
-    vimAlias = vimOptions.vimAlias;
-    configure = {
-      customRC = vimOptions.builtConfigRC;
-
-      packages.myVimPackage = {
-        start = buildConfigPlugins vimOptions.startPlugins;
-        opt = buildConfigPlugins vimOptions.optPlugins;
-      };
-    };
-  };
-in {
-  inherit (module) options config;
-  inherit (module._module.args) pkgs;
-  inherit neovim;
-}
+in
+  module.config.built.package

--- a/modules/lib/dag.nix
+++ b/modules/lib/dag.nix
@@ -102,4 +102,17 @@ in {
 
   entryAfter = nvim.dag.entryBetween [];
   entryBefore = before: nvim.dag.entryBetween before [];
+
+  resolveDag = {
+    name,
+    dag,
+    mapResult,
+  }: let
+    sortedDag = nvim.dag.topoSort dag;
+    result =
+      if sortedDag ? result
+      then mapResult sortedDag.result
+      else abort ("Dependency cycle in ${name}: " + builtins.toJSON sortedDag);
+  in
+    result;
 }

--- a/modules/lib/default.nix
+++ b/modules/lib/default.nix
@@ -2,4 +2,5 @@
   dag = import ./dag.nix {inherit lib;};
   booleans = import ./booleans.nix {inherit lib;};
   types = import ./types.nix {inherit lib;};
+  plugins = import ./plugins.nix {inherit lib;};
 }

--- a/modules/lib/plugins.nix
+++ b/modules/lib/plugins.nix
@@ -1,0 +1,3 @@
+{lib}: {
+  inputsToRaw = inputs: availablePlugins: lib.genAttrs availablePlugins (n: {src = inputs.${n};});
+}

--- a/modules/lib/types-plugin.nix
+++ b/modules/lib/types-plugin.nix
@@ -1,58 +1,18 @@
 {lib}:
 with lib; let
-  # Plugin must be same as input name
-  availablePlugins = [
-    "nvim-treesitter-context"
-    "gitsigns-nvim"
-    "plenary-nvim"
-    "nvim-lspconfig"
-    "nvim-treesitter"
-    "lspsaga"
-    "lspkind"
-    "nvim-lightbulb"
-    "lsp-signature"
-    "nvim-tree-lua"
-    "nvim-bufferline-lua"
-    "lualine"
-    "nvim-compe"
-    "nvim-autopairs"
-    "nvim-ts-autotag"
-    "nvim-web-devicons"
-    "tokyonight"
-    "bufdelete-nvim"
-    "nvim-cmp"
-    "cmp-nvim-lsp"
-    "cmp-buffer"
-    "cmp-vsnip"
-    "cmp-path"
-    "cmp-treesitter"
-    "crates-nvim"
-    "vim-vsnip"
-    "nvim-code-action-menu"
-    "trouble"
-    "null-ls"
-    "which-key"
-    "indent-blankline"
-    "nvim-cursorline"
-    "sqls-nvim"
-    "glow-nvim"
-    "telescope"
-    "rust-tools"
-    "onedark"
-    "catppuccin"
-    "open-browser"
-    "plantuml-syntax"
-    "plantuml-previewer"
-  ];
-
-  pluginsType = with types; listOf (nullOr (either (enum availablePlugins) package));
+  pluginsType = rawPlugins:
+    with types;
+      listOf (nullOr (either
+        (enum ((attrNames rawPlugins) ++ ["nvim-treesitter"]))
+        package));
 in {
   pluginsOpt = {
+    rawPlugins,
     description,
     default ? [],
   }:
     mkOption {
       inherit description default;
-      type = pluginsType;
+      type = pluginsType rawPlugins;
     };
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -22,6 +22,7 @@
     ./telescope
     ./git
     ./plantuml
+    ./build
   ];
 
   pkgsModule = {config, ...}: {


### PR DESCRIPTION
Move the package building inside the module. Can now specify the unwrapped neovim package and add extra "raw plugins" (aka inputs). Also now using the modern `makeNeovimConfig`. Closes #18 with the `rawPlugins` option.

Todo:
1. Documentation