### PR TITLE
Dracula theme

### DIFF
--- a/docs/release-notes/rl-0.1.adoc
+++ b/docs/release-notes/rl-0.1.adoc
@@ -55,3 +55,8 @@ https://github.com/antotocar34[antotocar34]:
 https://github.com/wanderer[wanderer]:
 
 * Added a module for plantuml which utilizes https://github.com/weirongxu/plantuml-previewer.vim[plantuml-previewer] and https://github.com/aklt/plantuml-syntax[plantuml-syntax]. The options <<opt-vim.languages.plantuml.plantumlPackage>> and <<opt-vim.languages.plantuml.javaPackage>> can be used to configure which version of the corresponding packages are used.
+
+https://github.com/MonaMayrhofer[MonaMayrhofer]:
+
+* Add support for https://github.com/Mofiqul/dracula.nvim[Mofiqul/dracula.nvim]
+* Add support for https://github.com/dracula/vim[dracula/vim]

--- a/flake.lock
+++ b/flake.lock
@@ -148,6 +148,22 @@
     "dracula": {
       "flake": false,
       "locked": {
+        "lastModified": 1671745750,
+        "narHash": "sha256-mKLU4xK3OggTJ8HDki/nj15OsxqAIS8C3lvnW54s5f4=",
+        "owner": "dracula",
+        "repo": "vim",
+        "rev": "eb577d47b0cfc9191bf04c414b4042d5f1a980f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dracula",
+        "repo": "vim",
+        "type": "github"
+      }
+    },
+    "dracula-mofiqul": {
+      "flake": false,
+      "locked": {
         "lastModified": 1680215271,
         "narHash": "sha256-f8zgWs0qmRjYAAfQsrNNYrmvFd2rjVnGwwdZu1pBJ58=",
         "owner": "Mofiqul",
@@ -766,6 +782,7 @@
         "cmp-vsnip": "cmp-vsnip",
         "crates-nvim": "crates-nvim",
         "dracula": "dracula",
+        "dracula-mofiqul": "dracula-mofiqul",
         "flake-utils": "flake-utils",
         "gitsigns-nvim": "gitsigns-nvim",
         "glow-nvim": "glow-nvim",

--- a/flake.lock
+++ b/flake.lock
@@ -145,6 +145,22 @@
         "type": "github"
       }
     },
+    "dracula": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680215271,
+        "narHash": "sha256-f8zgWs0qmRjYAAfQsrNNYrmvFd2rjVnGwwdZu1pBJ58=",
+        "owner": "Mofiqul",
+        "repo": "dracula.nvim",
+        "rev": "8653e7699810b63bda8ef267055cb4d4237670ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mofiqul",
+        "repo": "dracula.nvim",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -749,6 +765,7 @@
         "cmp-treesitter": "cmp-treesitter",
         "cmp-vsnip": "cmp-vsnip",
         "crates-nvim": "crates-nvim",
+        "dracula": "dracula",
         "flake-utils": "flake-utils",
         "gitsigns-nvim": "gitsigns-nvim",
         "glow-nvim": "glow-nvim",

--- a/flake.lock
+++ b/flake.lock
@@ -161,7 +161,7 @@
         "type": "github"
       }
     },
-    "dracula-mofiqul": {
+    "dracula-nvim": {
       "flake": false,
       "locked": {
         "lastModified": 1680215271,
@@ -782,7 +782,7 @@
         "cmp-vsnip": "cmp-vsnip",
         "crates-nvim": "crates-nvim",
         "dracula": "dracula",
-        "dracula-mofiqul": "dracula-mofiqul",
+        "dracula-nvim": "dracula-nvim",
         "flake-utils": "flake-utils",
         "gitsigns-nvim": "gitsigns-nvim",
         "glow-nvim": "glow-nvim",

--- a/flake.nix
+++ b/flake.nix
@@ -176,8 +176,13 @@
       flake = false;
     };
 
-    dracula = {
+    dracula-mofiqul = {
       url = "github:Mofiqul/dracula.nvim";
+      flake = false;
+    };
+
+    dracula = {
+      url = "github:dracula/vim";
       flake = false;
     };
 
@@ -290,6 +295,7 @@
       "onedark"
       "catppuccin"
       "dracula"
+      "dracula-mofiqul"
       "open-browser"
       "plantuml-syntax"
       "plantuml-previewer"

--- a/flake.nix
+++ b/flake.nix
@@ -176,6 +176,11 @@
       flake = false;
     };
 
+    dracula = {
+      url = "github:Mofiqul/dracula.nvim";
+      flake = false;
+    };
+
     # Rust crates
     crates-nvim = {
       url = "github:Saecki/crates.nvim";
@@ -284,6 +289,7 @@
       "rust-tools"
       "onedark"
       "catppuccin"
+      "dracula"
       "open-browser"
       "plantuml-syntax"
       "plantuml-previewer"

--- a/flake.nix
+++ b/flake.nix
@@ -176,7 +176,7 @@
       flake = false;
     };
 
-    dracula-mofiqul = {
+    dracula-nvim = {
       url = "github:Mofiqul/dracula.nvim";
       flake = false;
     };
@@ -295,7 +295,7 @@
       "onedark"
       "catppuccin"
       "dracula"
-      "dracula-mofiqul"
+      "dracula-nvim"
       "open-browser"
       "plantuml-syntax"
       "plantuml-previewer"

--- a/modules/statusline/supported_lualine_themes.nix
+++ b/modules/statusline/supported_lualine_themes.nix
@@ -2,4 +2,5 @@
   "tokyonight"
   "onedark"
   "catppuccin"
+  "dracula-nvim"
 ]

--- a/modules/theme/supported_themes.nix
+++ b/modules/theme/supported_themes.nix
@@ -75,5 +75,12 @@ in
       '';
       styles = [ "latte" "frappe" "macchiato" "mocha" ];
     };
+
+    dracula = {
+      setup = ''
+        require('dracula').setup({});
+        require('dracula').load();
+      '';
+    };
   };
 }

--- a/modules/theme/supported_themes.nix
+++ b/modules/theme/supported_themes.nix
@@ -76,7 +76,7 @@ in
       styles = [ "latte" "frappe" "macchiato" "mocha" ];
     };
 
-    dracula-mofiqul = {
+    dracula-nvim = {
       setup = ''
         require('dracula').setup({});
         require('dracula').load();

--- a/modules/theme/supported_themes.nix
+++ b/modules/theme/supported_themes.nix
@@ -76,10 +76,16 @@ in
       styles = [ "latte" "frappe" "macchiato" "mocha" ];
     };
 
-    dracula = {
+    dracula-mofiqul = {
       setup = ''
         require('dracula').setup({});
         require('dracula').load();
+      '';
+    };
+
+    dracula = {
+      setup = ''
+        vim.cmd[[colorscheme dracula]]
       '';
     };
   };


### PR DESCRIPTION
This adds support for https://github.com/Mofiqul/dracula.nvim and https://github.com/dracula/vim that are afaik the two most popular implementations of the [Dracula Theme
](https://draculatheme.com/)

Annoyingly they are different in a few regards and if you are used to one switching to the other is a little hassle - so i propose to support them both.

Mofiqul
![image](https://user-images.githubusercontent.com/43534802/229763320-691a3206-709b-4d94-8dcf-1a7cf3ef4b3b.png)

Official
![image](https://user-images.githubusercontent.com/43534802/229763559-88e0eab4-e22f-4091-97b6-7f4e2b86034a.png)

