### PR TITLE
Completion formatting and lspkind fixes

### DIFF
--- a/docs/release-notes/rl-0.1.adoc
+++ b/docs/release-notes/rl-0.1.adoc
@@ -44,6 +44,10 @@ vim.luaConfigRC = lib.nvim.dag.entryAnywhere "config here"
 
 * Removed the plugins document in the docs. Was too unwieldy to keep updated.
 
+* `vim.visual.lspkind` has been moved to <<opt-vim.lsp.lspkind.enable>>
+
+* Improved handling of completion formatting. When setting <<opt-vim.autocomplete.sources>>, can also include optional menu mapping. And can provide your own function with <<opt-vim.autocomplete.formatting.format>>.
+
 https://github.com/MoritzBoehme[MoritzBoehme]:
 
 * `catppuccin` theme is now available as a neovim theme <<opt-vim.theme.style>> and lualine theme <<opt-vim.statusline.lualine.theme>>.

--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
     "lspkind": {
       "flake": false,
       "locked": {
-        "lastModified": 1650298271,
-        "narHash": "sha256-0103K5lnzWCyuT/qwiBUo5PJ7lUX7fo+zNeEnQClI7A=",
+        "lastModified": 1663824370,
+        "narHash": "sha256-WwUQ+O2rIfD4yl0GFx70GsZc9nnhS7b2KWfNdaXCLmM=",
         "owner": "onsails",
         "repo": "lspkind-nvim",
-        "rev": "57e5b5dfbe991151b07d272a06e365a77cc3d0e7",
+        "rev": "c68b3a003483cf382428a43035079f78474cd11e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -336,7 +336,7 @@
         };
         vim.lsp = {
           formatOnSave = true;
-
+          lspkind.enable = false;
           lightbulb.enable = true;
           lspsaga.enable = false;
           nvimCodeActionMenu.enable = true;
@@ -346,7 +346,6 @@
         vim.visuals = {
           enable = true;
           nvimWebDevicons.enable = true;
-          lspkind.enable = true;
           indentBlankline = {
             enable = true;
             fillChar = "";

--- a/modules/completion/default.nix
+++ b/modules/completion/default.nix
@@ -7,8 +7,27 @@
 with lib;
 with builtins; let
   cfg = config.vim.autocomplete;
+  lspkindEnabled = config.vim.lsp.enable && config.vim.lsp.lspkind.enable;
   builtSources =
-    concatMapStringsSep "\n" (x: "{ name = '${x}'},") cfg.sources;
+    concatMapStringsSep
+    "\n"
+    (n: "{ name = '${n}'},")
+    (attrNames cfg.sources);
+
+  builtMaps =
+    concatStringsSep
+    "\n"
+    (mapAttrsToList
+      (n: v:
+        if v == null
+        then ""
+        else "${n} = '${v}',")
+      cfg.sources);
+
+  dagPlacement =
+    if lspkindEnabled
+    then nvim.dag.entryAfter ["lspkind"]
+    else nvim.dag.entryAnywhere;
 in {
   options.vim = {
     autocomplete = {
@@ -25,9 +44,40 @@ in {
       };
 
       sources = mkOption {
-        description = "List of source names for nvim-cmp";
-        type = with types; listOf str;
-        default = [];
+        description = nvim.nmd.asciiDoc ''
+          Attribute set of source names for nvim-cmp.
+
+          If an attribute set is provided, then the menu value of
+          `vim_item` in the format will be set to the value (if
+          utilizing the `nvim_cmp_menu_map` function).
+
+          Note: only use a single attribute name per attribute set
+        '';
+        type = with types; attrsOf (nullOr str);
+        default = {};
+        example = ''
+          {nvim-cmp = null; buffer = "[Buffer]";}
+        '';
+      };
+
+      formatting = {
+        format = mkOption {
+          description = nvim.nmd.asciiDoc ''
+            The function used to customize the appearance of the completion menu.
+
+            If <<opt-vim.lsp.lspkind.enable>> is true, then the function
+            will be called before modifications from lspkind.
+
+            Default is to call the menu mapping function.
+          '';
+          type = types.str;
+          default = "nvim_cmp_menu_map";
+          example = ''
+            function(entry, vim_item)
+              return vim_item
+            end
+          '';
+        };
       };
     };
   };
@@ -40,14 +90,28 @@ in {
       "cmp-path"
     ];
 
-    vim.autocomplete.sources = [
-      "nvim-cmp"
-      "vsnip"
-      "buffer"
-      "path"
-    ];
+    vim.autocomplete.sources = {
+      "nvim-cmp" = null;
+      "vsnip" = "[VSnip]";
+      "buffer" = "[Buffer]";
+      "crates" = "[Crates]";
+      "path" = "[Path]";
+    };
 
-    vim.luaConfigRC.completion = mkIf (cfg.type == "nvim-cmp") (nvim.dag.entryAnywhere ''
+    vim.luaConfigRC.completion = mkIf (cfg.type == "nvim-cmp") (dagPlacement ''
+      local nvim_cmp_menu_map = function(entry, vim_item)
+        -- name for each source
+        vim_item.menu = ({
+          ${builtMaps}
+        })[entry.source.name]
+        print(vim_item.menu)
+        return vim_item
+      end
+
+      ${optionalString lspkindEnabled ''
+        lspkind_opts.before = ${cfg.formatting.format}
+      ''}
+
       local has_words_before = function()
         local line, col = unpack(vim.api.nvim_win_get_cursor(0))
         return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match("%s") == nil
@@ -102,23 +166,12 @@ in {
           completeopt = 'menu,menuone,noinsert',
         },
         formatting = {
-          format = function(entry, vim_item)
-            -- type of kind
-            vim_item.kind = ${
-        optionalString (config.vim.visuals.lspkind.enable)
-        "require('lspkind').presets.default[vim_item.kind] .. ' ' .."
-      } vim_item.kind
-
-            -- name for each source
-            vim_item.menu = ({
-              buffer = "[Buffer]",
-              nvim_lsp = "[LSP]",
-              vsnip = "[VSnip]",
-              crates = "[Crates]",
-              path = "[Path]",
-            })[entry.source.name]
-            return vim_item
-          end,
+          format =
+      ${
+        if lspkindEnabled
+        then "lspkind.cmp_format(lspkind_opts)"
+        else cfg.formatting.format
+      },
         }
       })
       ${optionalString (config.vim.autopairs.enable && config.vim.autopairs.type == "nvim-autopairs") ''

--- a/modules/languages/rust.nix
+++ b/modules/languages/rust.nix
@@ -54,7 +54,7 @@ in {
 
       vim.startPlugins = ["crates-nvim"];
 
-      vim.autocomplete.sources = ["crates"];
+      vim.autocomplete.sources = {"crates" = "[Crates]";};
       vim.luaConfigRC.rust-crates = nvim.dag.entryAnywhere ''
         require('crates').setup {
           null_ls = {

--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -13,6 +13,7 @@ in {
     ./lspconfig.nix
     ./null-ls.nix
 
+    ./lspkind.nix
     ./lspsaga.nix
     ./nvim-code-action-menu.nix
     ./trouble.nix
@@ -28,7 +29,7 @@ in {
   config = mkIf cfg.enable {
     vim.startPlugins = optional usingNvimCmp "cmp-nvim-lsp";
 
-    vim.autocomplete.sources = ["nvim_lsp"];
+    vim.autocomplete.sources = {"nvim_lsp" = "[LSP]";};
 
     vim.luaConfigRC.lsp-setup = ''
       vim.g.formatsave = ${boolToString cfg.formatOnSave};

--- a/modules/lsp/lspkind.nix
+++ b/modules/lsp/lspkind.nix
@@ -1,0 +1,32 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib;
+with builtins; let
+  cfg = config.vim.lsp;
+in {
+  options.vim.lsp = {
+    lspkind = {
+      enable = mkEnableOption "vscode-like pictograms for lsp [lspkind]";
+
+      mode = mkOption {
+        description = "Defines how annotations are shown";
+        type = with types; enum ["text" "text_symbol" "symbol_text" "symbol"];
+        default = "symbol_text";
+      };
+    };
+  };
+
+  config = mkIf (cfg.enable && cfg.lspkind.enable) {
+    vim.startPlugins = ["lspkind"];
+    vim.luaConfigRC.lspkind = nvim.dag.entryAnywhere ''
+      local lspkind = require'lspkind'
+      local lspkind_opts = {
+        mode = '${cfg.lspkind.mode}'
+      }
+    '';
+  };
+}

--- a/modules/treesitter/treesitter.nix
+++ b/modules/treesitter/treesitter.nix
@@ -29,7 +29,7 @@ in {
       ["nvim-treesitter"]
       ++ optional usingNvimCmp "cmp-treesitter";
 
-    vim.autocomplete.sources = ["treesitter"];
+    vim.autocomplete.sources = {"treesitter" = "[Treesitter]";};
 
     # For some reason treesitter highlighting does not work on start if this is set before syntax on
     vim.configRC.treesitter-fold = mkIf cfg.fold (nvim.dag.entryBefore ["basic"] ''

--- a/modules/visuals/visuals.nix
+++ b/modules/visuals/visuals.nix
@@ -21,7 +21,7 @@ in {
 
     lspkind.enable = mkOption {
       type = types.bool;
-      description = "enable vscode-like pictograms for lsp [lspkind]";
+      description = "";
     };
 
     cursorWordline = {
@@ -65,12 +65,6 @@ in {
   };
 
   config = mkIf cfg.enable (mkMerge [
-    (mkIf cfg.lspkind.enable {
-      vim.startPlugins = ["lspkind"];
-      vim.luaConfigRC.lspkind = nvim.dag.entryAnywhere ''
-        require'lspkind'.init()
-      '';
-    })
     (mkIf cfg.indentBlankline.enable {
       vim.startPlugins = ["indent-blankline"];
       vim.luaConfigRC.indent-blankline = nvim.dag.entryAnywhere ''


### PR DESCRIPTION
Refactors visuals, moves `lspkind` to `vim.lsp`, and updates the completion formatting to be more configurable.

Closes #35 