### PR TITLE
LSP (fidget): Add support for j-hui/fidget.nvim

### DIFF
--- a/docs/release-notes/rl-0.1.adoc
+++ b/docs/release-notes/rl-0.1.adoc
@@ -65,6 +65,7 @@ https://github.com/MonaMayrhofer[MonaMayrhofer]:
 
 * Add support for https://github.com/Mofiqul/dracula.nvim[Mofiqul/dracula.nvim]
 * Add support for https://github.com/dracula/vim[dracula/vim]
+* Add support for https://github.com/j-hui/fidget.nvim[fidget.nvim]
 
 https://github.com/volfyd[volfyd]:
 

--- a/flake.lock
+++ b/flake.lock
@@ -177,6 +177,22 @@
         "type": "github"
       }
     },
+    "fidget": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1679938700,
+        "narHash": "sha256-rmJgfrEr/PYBq0S7j3tzRZvxi7PMMaAo0k528miXOQc=",
+        "owner": "j-hui",
+        "repo": "fidget.nvim",
+        "rev": "0ba1e16d07627532b6cae915cc992ecac249fb97",
+        "type": "github"
+      },
+      "original": {
+        "owner": "j-hui",
+        "repo": "fidget.nvim",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -799,6 +815,7 @@
         "crates-nvim": "crates-nvim",
         "dracula": "dracula",
         "dracula-nvim": "dracula-nvim",
+        "fidget": "fidget",
         "flake-utils": "flake-utils",
         "gitsigns-nvim": "gitsigns-nvim",
         "glow-nvim": "glow-nvim",

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,10 @@
       url = "github:kosayoda/nvim-lightbulb";
       flake = false;
     };
+    fidget = {
+      url = "github:j-hui/fidget.nvim";
+      flake = false;
+    };
 
     nvim-code-action-menu = {
       url = "github:weilbith/nvim-code-action-menu";
@@ -269,6 +273,7 @@
       "lspsaga"
       "lspkind"
       "nvim-lightbulb"
+      "fidget"
       "lsp-signature"
       "nvim-tree-lua"
       "nvim-bufferline-lua"

--- a/modules/lsp/default.nix
+++ b/modules/lsp/default.nix
@@ -19,6 +19,7 @@ in {
     ./trouble.nix
     ./lsp-signature.nix
     ./lightbulb.nix
+    ./fidget.nix
   ];
 
   options.vim.lsp = {

--- a/modules/lsp/fidget.nix
+++ b/modules/lsp/fidget.nix
@@ -1,0 +1,25 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib;
+with builtins; let
+  cfg = config.vim.lsp;
+in {
+  options.vim.lsp = {
+    fidget = {
+      enable = mkEnableOption "UI for nvim-lsp progress";
+    };
+  };
+
+  config = mkIf (cfg.enable && cfg.fidget.enable) {
+    vim.startPlugins = ["fidget"];
+
+    vim.luaConfigRC.fidget = nvim.dag.entryAnywhere ''
+      -- Enable fidget
+      require'fidget'.setup()
+    '';
+  };
+}


### PR DESCRIPTION
As the title says, adds support for https://github.com/j-hui/fidget.nvim which is a small plugin that displays LSP loading progress in a superfancy fashion - especially useful in large rust projects, where rust-analyzer takes a dozen seconds to start up. 