### PR TITLE
Themes (tokyonight, gruvbox): fix style option

### DIFF
--- a/modules/theme/supported_themes.nix
+++ b/modules/theme/supported_themes.nix
@@ -48,8 +48,7 @@ in {
     tokyonight = {
       setup = ''
         -- need to set style before colorscheme to apply
-        vim.g.tokyonight_style = '${cfg.style}'
-        vim.cmd[[colorscheme tokyonight]]
+        vim.cmd[[colorscheme tokyonight-${cfg.style}]]
       '';
       styles = ["day" "night" "storm"];
       defaultStyle = "night";
@@ -84,9 +83,7 @@ in {
     gruvbox = {
       setup = ''
         -- gruvbox theme
-        require('gruvbox').setup {
-          style = "${cfg.style}"
-        }
+        vim.o.background = "${cfg.style}"
         require('gruvbox').load()
       '';
       styles = ["dark" "light"];


### PR DESCRIPTION
Hello :wave: 

I just tried out using the light variants of the themes Gruvbox and tokyonight.
That didn't work so I adapted the config according to the readmes of those themes. 
I also had a quick look at the other themes, but there the style option seems to work.