### PR TITLE
Switch to putting config in a directory

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
     plugin-nvim-lightbulb.url = "github:kosayoda/nvim-lightbulb";
     plugin-nvim-lightbulb.flake = false;
 
-    plugin-fidget.url = "github:j-hui/fidget.nvim";
+    plugin-fidget.url = "github:j-hui/fidget.nvim/legacy";
     plugin-fidget.flake = false;
 
     plugin-nvim-code-action-menu.url = "github:weilbith/nvim-code-action-menu";

--- a/modules/core/default.nix
+++ b/modules/core/default.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 with lib;
@@ -29,8 +28,20 @@ in {
     };
 
     luaConfigRC = mkOption {
-      description = "vim lua config";
+      description = "nvim lua config";
       type = nvim.types.dagOf types.lines;
+      default = {};
+    };
+
+    ftplugins = mkOption {
+      description = "ftplugin sources";
+      type = with types; attrsOf str;
+      default = {};
+    };
+
+    lua.modules = mkOption {
+      description = "vim lua modules";
+      type = with types; attrsOf str;
       default = {};
     };
 

--- a/modules/languages/clang.nix
+++ b/modules/languages/clang.nix
@@ -14,8 +14,8 @@ with builtins; let
       package = pkgs.ccls;
       lspConfig = ''
         lspconfig.ccls.setup{
-          capabilities = capabilities;
-          on_attach=default_on_attach;
+          capabilities = lsp.capabilities;
+          on_attach = lsp.default_on_attach;
           cmd = {"${pkgs.ccls}/bin/ccls"};
           ${optionalString (cfg.lsp.opts != null) "init_options = ${cfg.lsp.cclsOpts}"}
         }

--- a/modules/languages/go.nix
+++ b/modules/languages/go.nix
@@ -14,8 +14,8 @@ with builtins; let
       package = pkgs.gopls;
       lspConfig = ''
         lspconfig.gopls.setup {
-          capabilities = capabilities;
-          on_attach = default_on_attach;
+          capabilities = lsp.capabilities;
+          on_attach = lsp.default_on_attach;
           cmd = {"${cfg.lsp.package}/bin/gopls", "serve"},
         }
       '';

--- a/modules/languages/nix.nix
+++ b/modules/languages/nix.nix
@@ -8,8 +8,8 @@ with lib;
 with builtins; let
   cfg = config.vim.languages.nix;
 
-  useFormat = "on_attach = default_on_attach";
-  noFormat = "on_attach = attach_keymaps";
+  useFormat = "on_attach = lsp.default_on_attach";
+  noFormat = "on_attach = lsp.attach_keymaps";
 
   defaultServer = "nil";
   servers = {
@@ -17,8 +17,9 @@ with builtins; let
       package = pkgs.rnix-lsp;
       internalFormatter = cfg.format.type == "nixpkgs-fmt";
       lspConfig = ''
-        lspconfig.rnix.setup{
-          capabilities = capabilities,
+        local lsp = require('flake/lsp')
+        require('lspconfig').rnix.setup{
+          capabilities = lsp.capabilities,
         ${
           if (cfg.format.enable && cfg.format.type == "nixpkgs-fmt")
           then useFormat
@@ -33,8 +34,9 @@ with builtins; let
       package = pkgs.nil;
       internalFormatter = true;
       lspConfig = ''
-        lspconfig.nil_ls.setup{
-          capabilities = capabilities,
+        local lsp = require('flake/lsp')
+        require('lspconfig').nil_ls.setup{
+          capabilities = lsp.capabilities,
         ${
           if cfg.format.enable
           then useFormat
@@ -146,7 +148,7 @@ in {
 
     (mkIf cfg.lsp.enable {
       vim.lsp.lspconfig.enable = true;
-      vim.lsp.lspconfig.sources.nix-lsp = servers.${cfg.lsp.server}.lspConfig;
+      vim.ftplugins.nix = servers.${cfg.lsp.server}.lspConfig;
     })
 
     (mkIf (cfg.format.enable && !servers.${cfg.lsp.server}.internalFormatter) {

--- a/modules/languages/python.nix
+++ b/modules/languages/python.nix
@@ -14,8 +14,8 @@ with builtins; let
       package = pkgs.nodePackages.pyright;
       lspConfig = ''
         lspconfig.pyright.setup{
-          capabilities = capabilities;
-          on_attach = default_on_attach;
+          capabilities = lsp.capabilities;
+          on_attach = lsp.default_on_attach;
           cmd = {"${cfg.lsp.package}/bin/pyright-langserver", "--stdio"}
         }
       '';

--- a/modules/languages/rust.nix
+++ b/modules/languages/rust.nix
@@ -76,7 +76,7 @@ in {
         local rt = require('rust-tools')
 
         rust_on_attach = function(client, bufnr)
-          default_on_attach(client, bufnr)
+          lsp.default_on_attach(client, bufnr)
           local opts = { noremap=true, silent=true, buffer = bufnr }
           vim.keymap.set("n", "<leader>ris", rt.inlay_hints.set, opts)
           vim.keymap.set("n", "<leader>riu", rt.inlay_hints.unset, opts)
@@ -96,7 +96,7 @@ in {
             }
           },
           server = {
-            capabilities = capabilities,
+            capabilities = lsp.capabilities,
             on_attach = rust_on_attach,
             cmd = {"${cfg.lsp.package}/bin/rust-analyzer"},
             settings = {

--- a/modules/languages/sql.nix
+++ b/modules/languages/sql.nix
@@ -17,7 +17,7 @@ with builtins; let
         lspconfig.sqls.setup {
           on_attach = function(client)
             client.server_capabilities.execute_command = true
-            on_attach_keymaps(client, bufnr)
+            lsp.on_attach_keymaps(client, bufnr)
             require'sqls'.setup{}
           end,
           cmd = { "${cfg.lsp.package}/bin/sqls", "-config", string.format("%s/config.yml", vim.fn.getcwd()) }

--- a/modules/languages/ts.nix
+++ b/modules/languages/ts.nix
@@ -14,8 +14,8 @@ with builtins; let
       package = pkgs.nodePackages.typescript-language-server;
       lspConfig = ''
         lspconfig.tsserver.setup {
-          capabilities = capabilities;
-          on_attach = attach_keymaps,
+          capabilities = lsp.capabilities;
+          on_attach = lsp.attach_keymaps,
           cmd = { "${cfg.lsp.package}/bin/typescript-language-server", "--stdio" }
         }
       '';
@@ -55,7 +55,7 @@ with builtins; let
   };
 in {
   options.vim.languages.ts = {
-    enable = mkEnableOption "SQL language support";
+    enable = mkEnableOption "TypeScript language support";
 
     treesitter = {
       enable = mkOption {

--- a/modules/languages/zig.nix
+++ b/modules/languages/zig.nix
@@ -9,7 +9,7 @@ with builtins; let
   cfg = config.vim.languages.zig;
 in {
   options.vim.languages.zig = {
-    enable = mkEnableOption "SQL language support";
+    enable = mkEnableOption "Zig language support";
 
     treesitter = {
       enable = mkOption {
@@ -48,8 +48,8 @@ in {
       vim.lsp.lspconfig.enable = true;
       vim.lsp.lspconfig.sources.zig-lsp = ''
         lspconfig.zls.setup {
-          capabilities = capabilities,
-          on_attach=default_on_attach,
+          capabilities = lsp.capabilities,
+          on_attach = lsp.default_on_attach,
           cmd = {"${cfg.lsp.package}/bin/zls"},
           settings = {
             ["zls"] = {

--- a/modules/lsp/lspconfig.nix
+++ b/modules/lsp/lspconfig.nix
@@ -1,5 +1,4 @@
 {
-  pkgs,
   config,
   lib,
   ...

--- a/modules/lsp/null-ls.nix
+++ b/modules/lsp/null-ls.nix
@@ -3,7 +3,6 @@
 #   -- Enable null-ls
 # '';
 {
-  pkgs,
   config,
   lib,
   ...
@@ -39,7 +38,7 @@ in {
           debounce = 250,
           default_timeout = 5000,
           sources = ls_sources,
-          on_attach=default_on_attach
+          on_attach = require('flake/lsp').default_on_attach
         })
       '';
     }


### PR DESCRIPTION
Instead of using `wrapRc` to reference to add the `-u` argument to neovim, we add the directory to the `XDG_CONFIG_DIRS`, which neovim will read on startup.

This allows us to do a few nice things:
  * Write commonly used code in modules. This is used to to create an internal module, `flake/lsp`, which contains the functions used for `on_attach` and the `capabilities`. Users can also add their own modules via `vim.lua.modules.mymodule = "<code>";`.
  * Put language specific code in `ftplugin/<lang>.lua`. The `nix` config was migrated to use this approach as an example.