### PR TITLE
Languages (java,kotlin,terraform): add treesitter options

### DIFF
--- a/modules/languages/default.nix
+++ b/modules/languages/default.nix
@@ -9,19 +9,22 @@ with lib; let
 in
 {
   imports = [
+    ./bash.nix
     ./clang.nix
     ./go.nix
+    ./html.nix
+    ./java.nix
+    ./kotlin.nix
+    ./markdown.nix
     ./nix.nix
+    ./plantuml.nix
     ./python.nix
     ./rust.nix
     ./sql.nix
+    ./terraform.nix
+    ./tidal.nix
     ./ts.nix
     ./zig.nix
-    ./markdown.nix
-    ./plantuml.nix
-    ./tidal.nix
-    ./html.nix
-    ./bash.nix
   ];
 
   options.vim.languages = {

--- a/modules/languages/java.nix
+++ b/modules/languages/java.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib;
+with builtins; let
+  cfg = config.vim.languages.java;
+in {
+  options.vim.languages.java = {
+    enable = mkEnableOption "Java language support";
+
+    treesitter = {
+      enable = mkOption {
+        description = "Enable Java treesitter";
+        type = types.bool;
+        default = config.vim.languages.enableTreesitter;
+      };
+      package = nvim.options.mkGrammarOption pkgs "java";
+    };
+  };
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+  ]);
+}

--- a/modules/languages/kotlin.nix
+++ b/modules/languages/kotlin.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib;
+with builtins; let
+  cfg = config.vim.languages.kotlin;
+in {
+  options.vim.languages.kotlin = {
+    enable = mkEnableOption "Kotlin language support";
+
+    treesitter = {
+      enable = mkOption {
+        description = "Enable kotlin treesitter";
+        type = types.bool;
+        default = config.vim.languages.enableTreesitter;
+      };
+      package = nvim.options.mkGrammarOption pkgs "kotlin";
+    };
+  };
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+  ]);
+}

--- a/modules/languages/terraform.nix
+++ b/modules/languages/terraform.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib;
+with builtins; let
+  cfg = config.vim.languages.terraform;
+in {
+  options.vim.languages.terraform = {
+    enable = mkEnableOption "Terraform language support";
+
+    treesitter = {
+      enable = mkOption {
+        description = "Enable terraform treesitter";
+        type = types.bool;
+        default = config.vim.languages.enableTreesitter;
+      };
+      package = nvim.options.mkGrammarOption pkgs "terraform";
+    };
+  };
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+  ]);
+}


### PR DESCRIPTION
This is only enabling treesitter support for java, kotlin and terraform. Also I did sort the imports in defaults.nix 