### PR TITLE
Languages(cmake): add basic treesitter options

### DIFF
--- a/modules/languages/cmake.nix
+++ b/modules/languages/cmake.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+with lib;
+with builtins; let
+  cfg = config.vim.languages.cmake;
+in {
+  options.vim.languages.cmake = {
+    enable = mkEnableOption "CMake language support";
+
+    treesitter = {
+      enable = mkOption {
+        description = "Enable CMake treesitter";
+        type = types.bool;
+        default = config.vim.languages.enableTreesitter;
+      };
+      package = nvim.options.mkGrammarOption pkgs "cmake";
+    };
+  };
+  config = mkIf cfg.enable (mkMerge [
+    (mkIf cfg.treesitter.enable {
+      vim.treesitter.enable = true;
+      vim.treesitter.grammars = [cfg.treesitter.package];
+    })
+  ]);
+}

--- a/modules/languages/default.nix
+++ b/modules/languages/default.nix
@@ -11,6 +11,7 @@ in
   imports = [
     ./bash.nix
     ./clang.nix
+    ./cmake.nix
     ./go.nix
     ./html.nix
     ./java.nix


### PR DESCRIPTION
When opening a CMakeLists file it complains about not able to run tree-sitter parsers. This will fix it and makes syntax highlight.